### PR TITLE
Prevents AwesomeNotifications from clobbering existing UNNotificationCategory objects

### DIFF
--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -693,7 +693,10 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
                 intentIdentifiers: [],
                 options: .customDismissAction
             )
-            UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+
+            UNUserNotificationCenter.current().getNotificationCategories(completionHandler: { results in
+                UNUserNotificationCenter.current().setNotificationCategories(results.union([categoryObject]))
+            })
         }
         
         SwiftAwesomeNotificationsPlugin.appLifeCycle = NotificationLifeCycle.AppKilled

--- a/ios/Classes/lib/notifications/NotificationBuilder.swift
+++ b/ios/Classes/lib/notifications/NotificationBuilder.swift
@@ -402,7 +402,10 @@ public class NotificationBuilder {
                 intentIdentifiers: [],
                 options: .customDismissAction
             )
-            UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+            // UNUserNotificationCenter.current().setNotificationCategories([categoryObject])
+            UNUserNotificationCenter.current().getNotificationCategories(completionHandler: { results in
+                UNUserNotificationCenter.current().setNotificationCategories(results.union([categoryObject]))
+            })
         }
     }
     


### PR DESCRIPTION
One issue for discussion:  I'm not sure how/if hashCode is overridden in UNNotificationCategory, so it is theoretically possible that set operations are a no-op.