### PR TITLE
Removes AwesomeNotifications as UNNotificationCenterDelegate

### DIFF
--- a/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
+++ b/ios/Classes/lib/SwiftAwesomeNotificationsPlugin.swift
@@ -164,9 +164,9 @@ public class SwiftAwesomeNotificationsPlugin: NSObject, FlutterPlugin, UNUserNot
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         
         // Set ourselves as the UNUserNotificationCenter delegate, but also preserve any existing delegate...
-        let notificationCenter = UNUserNotificationCenter.current()
-        _originalNotificationCenterDelegate = notificationCenter.delegate
-        notificationCenter.delegate = self
+//         let notificationCenter = UNUserNotificationCenter.current()
+//         _originalNotificationCenterDelegate = notificationCenter.delegate
+//         notificationCenter.delegate = self
         
         //enableFirebase(application)
         //enableScheduler(application)


### PR DESCRIPTION
Because we use FirebaseMessaging to handle all UNNotificationCenter delegate calls (in particular, to decide whether or not to show a notification), we don't want AwesomeNotifications interfering.  